### PR TITLE
Update PurchaseRequest.php

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -163,7 +163,7 @@ class PurchaseRequest extends AbstractRequest
     protected function generateSignature($merchantParameters)
     {
         $key = base64_decode($this->getParameter('merchantKey'));
-        $key = Encryptor::encrypt_3DES($this->getToken(), $key);
+        $key = Encryptor::encrypt_3DES($this->getTransactionId(), $key);
         $res = hash_hmac('sha256', $merchantParameters, $key, true);
 
         return base64_encode($res);


### PR DESCRIPTION
Hola,
Estaba mirando de usar el repositorio y me he fijado que lo que se está usando para generar la key es el método $this->getToken(), el cual viene vacío al especificar el $this->getTransactionId(). 
Esto resultaba en que se generaba la key en base a un string vacío y luego daba error al redirigir a la pasarela.

Saludos