### PR TITLE
Añadir completePurchase()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "omnipay/common": "2.*"
+        "omnipay/common": "2.*",
+        "redsys/messages": "*"
     },
     "autoload": {
         "psr-4": { "Omnipay\\Sermepa\\": "src/" }

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -100,6 +100,11 @@ class Gateway extends AbstractGateway
             return $this->createRequest('\Omnipay\Sermepa\Message\PurchaseRequest', $parameters);
         }
     }
+    
+    public function completePurchase(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Sermepa\Message\CompletePurchaseRequest', $parameters);
+    }    
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request

--- a/src/Message/CompletePurchaseRequest.php
+++ b/src/Message/CompletePurchaseRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Omnipay\Sermepa\Message;
+
+use Symfony\Component\HttpFoundation\Request;
+use Omnipay\Sermepa\Encryptor\Encryptor;
+use Omnipay\Sermepa\Exception\BadSignatureException;
+use Omnipay\Sermepa\Exception\CallbackException;
+
+/**
+ * Sermepa (Redsys) Complete Purchase Request
+ */
+class CompletePurchaseRequest extends PurchaseRequest
+{
+    public function getData()
+    {
+        $request = Request::createFromGlobals();
+
+        $rawParameters = $request->get('Ds_MerchantParameters');
+
+        $decodedParameters = json_decode(base64_decode(strtr($rawParameters, '-_', '+/')), true);
+
+        if (!$this->checkSignature(
+            $rawParameters,
+            $decodedParameters['Ds_Order'],
+            $request->get('Ds_Signature')
+        )
+        ) {
+            throw new BadSignatureException();
+        }
+
+        //check response, code "000" to "099" means success
+        if ((int)$decodedParameters['Ds_Response'] <= 99) {
+            $success = true;
+        } else {
+            $success = false;
+        }
+
+        return [
+            'success' => $success,
+            'decodedParameters' => $decodedParameters
+        ];
+    }
+
+    public function sendData($data)
+    {
+        return $this->response = new CompletePurchaseResponse($this, $data);
+    }
+
+    private function checkSignature($data, $orderId, $expectedSignature)
+    {
+        $key = Encryptor::encrypt_3DES($orderId, base64_decode($this->getParameter('merchantKey')));
+
+        return strtr(base64_encode(hash_hmac('sha256', $data, $key, true)), '+/', '-_') == $expectedSignature;
+    }
+}

--- a/src/Message/CompletePurchaseResponse.php
+++ b/src/Message/CompletePurchaseResponse.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Omnipay\Sermepa\Message;
+
+use Omnipay\Common\Message\AbstractResponse;
+use Redsys\Messages\Messages;
+
+/**
+ * Sermepa (Redsys) Complete Purchase Response
+ */
+class CompletePurchaseResponse extends AbstractResponse
+{
+    public function isSuccessful()
+    {
+        if ($this->data['success'] === true) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public function getMessage()
+    {
+        $messageData = Messages::getByCode($this->data['decodedParameters']['Ds_Response']);
+
+        if ($messageData) {
+            $message = $messageData['code']. ' - ' . $messageData['message'];
+            if ($messageData['detail']) {
+                $message .= '. '. $messageData['detail'];
+            }
+        } else {
+            $message = $this->data['decodedParameters']['Ds_Response'];
+        }
+
+        return $message;
+    }
+}


### PR DESCRIPTION
Buenas de nuevo,
Gracias por añadir el anterior cambio.

No soy muy entendido de omnipay pero he pensado que sería interesante hacer el proceso de verificación más compatible con otros gateways. Para ello sería útil añadir el método completePurchase antes que usar checkCallbackResponse() directamente.

De está forma se podría usar de la forma siguiente cuando se reciban los parámetros get de Redsys:

$response = $gateway->completePurchase()->send();
//Se recuperan los parámetros GET de redsys y se comprueban tal y como hace CallbackResponse

if ($response->isSuccessful()) {
  //Operación realizada correctamente
} else {
 //Operación fallida
  echo $response->getMessage()
}

Además con getMessage() se devuelve la información descriptiva del error usando el repositorio redsys/messages.
Solo se lanzaría excepción en caso de que la firma no fuera correcta.

Saludos
