### PR TITLE
Add support to authorize payments

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -136,6 +136,24 @@ class Gateway extends AbstractGateway
      * @param array $parameters
      * @return \Omnipay\Common\Message\AbstractRequest|\Omnipay\Common\Message\RequestInterface
      */
+    public function authorize(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Sermepa\Message\AuthorizeRequest', $parameters);
+    }
+
+    /**
+     * @param array $parameters
+     * @return \Omnipay\Common\Message\AbstractRequest|\Omnipay\Common\Message\RequestInterface
+     */
+    public function completeAuthorize(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Sermepa\Message\CompleteAuthorizeRequest', $parameters);
+    }
+
+    /**
+     * @param array $parameters
+     * @return \Omnipay\Common\Message\AbstractRequest|\Omnipay\Common\Message\RequestInterface
+     */
     public function purchase(array $parameters = array())
     {
         if (isset($parameters['recurrent']) && $parameters['recurrent']) {

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Omnipay\Sermepa\Message;
+
+/**
+ * Sermepa (Redsys) Authorize Request
+ *
+ * @author Nerburish <nerburish@gmail.com>
+ */
+class AuthorizeRequest extends PurchaseRequest
+{
+    public function getTransactionType()
+    {
+        return '1';
+    }
+}

--- a/src/Message/CompleteAuthorizeRequest.php
+++ b/src/Message/CompleteAuthorizeRequest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Omnipay\Sermepa\Message;
+
+/**
+ * Sermepa (Redsys) Complete Authorize Request
+ */
+class CompleteAuthorizeRequest extends CompletePurchaseRequest
+{
+    public function sendData($data)
+    {
+        return $this->response = new CompleteAuthorizeResponse($this, $data);
+    }
+}

--- a/src/Message/CompleteAuthorizeResponse.php
+++ b/src/Message/CompleteAuthorizeResponse.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Omnipay\Sermepa\Message;
+
+/**
+ * Sermepa (Redsys) Complete Authorize Response
+ */
+class CompleteAuthorizeResponse extends CompletePurchaseResponse {}


### PR DESCRIPTION
He añadido las clases para para permitir autorizar compras sin realizar la captura.
En esencia lo único que cambia para redsys es que el tipo de operación es 1 en vez de 0, por lo que lo que he hecho es heredar las respectivas clases de "purchase".

saludos