### PR TITLE
Remove unused libraries. Fix PHP8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,6 @@
     "php": ">=5.6",
     "omnipay/common": "3.*",
     "redsys/messages": "*",
-    "php-http/curl-client": "^1.7",
-    "guzzlehttp/psr7": "^1.4",
     "php-http/message": "^1.7"
   },
   "autoload": {


### PR DESCRIPTION
Some dependencies are never used. `php-http` requires PHP < 8, which prevents installation of this package through composer in those environments.